### PR TITLE
[Fix] Extract correct name from yaml path

### DIFF
--- a/src/helpers/loadSync.js
+++ b/src/helpers/loadSync.js
@@ -5,7 +5,7 @@ const { Schema } = require('@kravc/schema')
 const { readFileSync } = require('fs')
 
 const loadSync = (yamlPath) => {
-  const id     = yamlPath.split('.')[0].split('/').reverse()[0]
+  const id     = yamlPath.split('/').reverse()[0].split('.yaml')[0]
   const source = load(readFileSync(yamlPath))
 
   return new Schema(source, id)


### PR DESCRIPTION
This used to fail when the system username had a "." in it.